### PR TITLE
Delay deletion Eluna state for maps

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -70,9 +70,6 @@ Map::~Map()
     if (Eluna* e = GetEluna())
         if (Instanceable())
             e->FreeInstanceId(GetInstanceId());
-
-    delete eluna;
-    eluna = nullptr;
 #endif
     UnloadAll(true);
 
@@ -98,6 +95,11 @@ Map::~Map()
         transport->ResetMap();
         delete transport;
     }
+ 
+ #ifdef BUILD_ELUNA
+    delete eluna;
+    eluna = nullptr;
+#endif
 }
 
 uint32 Map::GetCurrentMSTime() const


### PR DESCRIPTION
This ensures all objects on the map has been unloaded properly and their event processor has been deleted.

Fixes #5